### PR TITLE
template: Fix template to not show `share` when the list is empty

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -63,11 +63,11 @@
             </p>
             
             <p class="copyright-item">
-                {{ if $.Param "socialShare" }}
+                {{ if and ( $.Param "socialShare" ) (gt (len ($.Param "share")) 0) }}
                 <span>{{ i18n "Share" }}:</span>
                 <span>{{ partial "share-links" . }}</span>
+                {{ end }}
             </p>
-                       {{ end }}
 
             {{ with .Site.Params.license }} 
             <p class="copyright-item">


### PR DESCRIPTION
When there are no items under `params.share` in config.toml the blog would still have a `Share:` with no buttons

The PR is to not have `Share:` when there are no items in `params.share` in config