### PR TITLE
Update: .Params.share -> .Site.Params.share

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -18,8 +18,7 @@
                           <a href="{{ .Permalink }}"> {{ $name }} </a>
                         {{ end -}}
                         {{ end }}
-                </span>
-                {{- end }}
+                </span> {{- end }}
                 <i class="iconfont icon-timer"></i>
                 {{.ReadingTime }} min
         </div>
@@ -61,9 +60,9 @@
                     <span>{{ i18n "Words" }}:</span>
                    <span>{{ .WordCount }}</span>
             </p>
-            
+
             <p class="copyright-item">
-                {{ if and ( $.Param "socialShare" ) (gt (len ($.Param "share")) 0) }}
+                {{ if and ( $.Site.Params.socialShare ) (gt (len ($.Site.Params.share)) 0) }}
                 <span>{{ i18n "Share" }}:</span>
                 <span>{{ partial "share-links.html" . }}</span>
                 {{ end }}

--- a/layouts/partials/share-links.html
+++ b/layouts/partials/share-links.html
@@ -1,66 +1,66 @@
-{{ if or .Params.socialShare (and .Site.Params.socialShare (ne .Params.socialShare false)) }}
+{{ if .Site.Params.socialShare }}
 
-      {{ if or .Params.Share.Twitter (and .Site.Params.Share.Twitter (ne .Params.Share.Twitter false)) }}
+      {{ if .Site.Params.Share.Twitter }}
         <a href="//twitter.com/share?url={{ .Permalink }}&amp;text={{ .Title }}&amp;via={{ .Site.Params.Social.Twitter }}" target="_blank" title="Share on Twitter">
           <i class="iconfont icon-twitter"></i>
         </a>
         {{ end }}
       
-      {{ if or .Params.Share.Facebook (and .Site.Params.Share.Facebook (ne .Params.Share.Facebook false)) }}
+      {{ if .Site.Params.Share.Facebook }}
         <a href="//www.facebook.com/sharer/sharer.php?u={{ .Permalink }}" target="_blank" title="Share on Facebook">
           <i class="iconfont icon-facebook"></i>
         </a>
         {{ end }}
       
-      {{ if or .Params.Share.Reddit (and .Site.Params.Share.Reddit (ne .Params.Share.Reddit false)) }}
+      {{ if .Site.Params.Share.Reddit }}
         <a href="//reddit.com/submit?url={{ .Permalink }}&amp;title={{ .Title }}" target="_blank" title="Share on Reddit">
           <i class="iconfont icon-reddit"></i>
         </a>
         {{ end }}
       
-      {{ if or .Params.Share.Linkedin (and .Site.Params.Share.Linkedin (ne .Params.Share.Linkedin false)) }}
+      {{ if .Site.Params.Share.Linkedin }}
         <a href="//www.linkedin.com/shareArticle?url={{ .Permalink }}&amp;title={{ .Title }}" target="_blank" title="Share on LinkedIn">
           <i class="iconfont icon-linkedin"></i>
         </a>
         {{ end }}
       
-      {{ if or .Params.Share.Pinterest (and .Site.Params.Share.Pinterest (ne .Params.Share.Pinterest false)) }}
+      {{ if .Site.Params.Share.Pinterest }}
         <a href="//www.pinterest.com/pin/create/button/?url={{ .Permalink }}&amp;description={{ .Title }}" target="_blank" title="Share on Pinterest">
           <i class="iconfont icon-pinterest"></i>
         </a>
         {{ end }}
         
-      {{ if or .Params.Share.HackerNews (and .Site.Params.Share.HackerNews (ne .Params.Share.HackerNews false)) }}
+      {{ if .Site.Params.Share.HackerNews }}
         <a href="//news.ycombinator.com/submitlink?u={{ .Permalink }}&amp;description={{ .Title }}" target="_blank" title="Share on Hacker News">
           <i class="iconfont icon-ycombinator"></i>
         </a>
         {{ end }}
         
-      {{ if or .Params.Share.Mix (and .Site.Params.Share.Mix (ne .Params.Share.Mix false)) }}
+      {{ if .Site.Params.Share.Mix }}
         <a href="//mix.com/add?url={{ .Permalink }}&amp;description={{ .Title }}" target="_blank" title="Share on Mix">
             <i class="iconfont icon-mix"></i>
           </a>
           {{ end }}
 
-          {{ if or .Params.Share.Tumblr (and .Site.Params.Share.Tumblr (ne .Params.Share.Tumblr false)) }}
+          {{ if .Site.Params.Share.Tumblr }}
         <a href="//www.tumblr.com/widgets/share/tool?canonicalUrl={{ .Permalink }}&amp;title={{ .Title }}" target="_blank" title="Share on Tumblr">
             <i class="iconfont icon-tumblr"></i>
           </a>
           {{ end }}
 
-          {{ if or .Params.Share.VKontakte (and .Site.Params.Share.VKontakte (ne .Params.Share.VKontakte false)) }}
+          {{ if .Site.Params.Share.VKontakte }}
         <a href="//vk.com/share.php?url={{ .Permalink }}&amp;title={{ .Title }}" target="_blank" title="Share on VKontakte ">
             <i class="iconfont icon-vk"></i>
           </a>
           {{ end }}
 
-          {{ if or .Params.Share.Douban (and .Site.Params.Share.Douban (ne .Params.Share.Douban false)) }}
+          {{ if .Site.Params.Share.Douban }}
         <a href="//www.douban.com/recommend/?url={{ .Permalink }}&amp;title={{ .Title }}" target="_blank" title="Share on Douban ">
             <i class="iconfont icon-douban"></i>
           </a>
           {{ end }}
 
-          {{ if or .Params.Share.Weibo (and .Site.Params.Share.Weibo (ne .Params.Share.Weibo false)) }}
+          {{ if .Site.Params.Share.Weibo }}
         <a href="//service.weibo.com/share/share.php?url={{ .Permalink }}&amp;appkey=&amp;title={{ .Title }}" target="_blank" title="Share on Douban ">
             <i class="iconfont icon-weibo"></i>
           </a>


### PR DESCRIPTION
With hugo v0.89.1, `.Params.share` and `.Param "share"` is not available. Instead them with `.Site.Params.share`.