### PR TITLE
Fixed the Google Scholar link

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -158,7 +158,7 @@
 <a href="https://vine.co/" rel="me noopener noreffer" target="_blank"><i class="iconfont icon-vine"></i></a>
 {{ end }}
 {{ with .Site.Params.Social.Googlescholar}}
-<a href="https://scholar.google.com/citations?{{ . }}" rel="me noopener noreffer" target="_blank"><i class="iconfont icon-Googlescholar"></i></a>
+<a href="https://scholar.google.com/citations?user={{ . }}" rel="me noopener noreffer" target="_blank"><i class="iconfont icon-Googlescholar"></i></a>
 {{ end }}
 {{ with .Site.Params.Social.Researchgate}}
 <a href="https://www.researchgate.net/profile/{{ . }}" rel="me noopener noreffer" target="_blank"><i class="iconfont icon-researchgate"></i></a>


### PR DESCRIPTION
The old URL format didn't include the user parameter that was leading the visitor to create a new profile of their own.