### PR TITLE
Fix the shortcode link to a tweet using just the ID number of the tweet

### DIFF
--- a/content/posts/theme-documentation-built-in-shortcodes/index.en.md
+++ b/content/posts/theme-documentation-built-in-shortcodes/index.en.md
@@ -143,12 +143,12 @@ The rendered output looks like this:
 Example `tweet` input:
 
 ```markdown
-{{</* tweet 917359331535966209 */>}}
+{{</* tweet id="917359331535966209" user="Fastbyte01" */>}}
 ```
 
 The rendered output looks like this:
 
-{{< tweet 917359331535966209 >}}
+{{< tweet id="917359331535966209" user+"Fastbyte01" >}}
 
 ## 8 vimeo
 

--- a/content/posts/theme-documentation-built-in-shortcodes/index.en.md
+++ b/content/posts/theme-documentation-built-in-shortcodes/index.en.md
@@ -148,7 +148,7 @@ Example `tweet` input:
 
 The rendered output looks like this:
 
-{{< tweet id="917359331535966209" user+"Fastbyte01" >}}
+{{< tweet id="917359331535966209" user="Fastbyte01" >}}
 
 ## 8 vimeo
 


### PR DESCRIPTION
Fix for ERROR The "tweet" shortcode requires two named parameters: user and id. See "/themes/KeepIt/content/posts/theme-documentation-built-in-shortcodes/index.en.md:151:1"